### PR TITLE
Minor fix fuel efficiency metric

### DIFF
--- a/aviary/metrics/fuel_efficiency_metric.py
+++ b/aviary/metrics/fuel_efficiency_metric.py
@@ -51,4 +51,6 @@ def fuel_efficiency_metric(current_flight_level, requested_flight_level, initial
 
     num = abs(max(requested_flight_level, initial_flight_level) - current_flight_level)
     denom = abs(requested_flight_level - initial_flight_level)
+    if denom == 0:
+        return 0
     return -1 * min(1, num/denom)

--- a/aviary/test/unit/metrics/test_fuel_efficiency_metric.py
+++ b/aviary/test/unit/metrics/test_fuel_efficiency_metric.py
@@ -43,3 +43,8 @@ def test_fuel_efficiency_metric():
     result = fuel_efficiency_metric(current_flight_level=100, requested_flight_level=200, initial_flight_level=400)
     assert result == -1 # Score is always in the interval [-1, 0].
 
+    ## Entered at requested flight level:
+
+    # No commands sent to aircraft
+    result = fuel_efficiency_metric(current_flight_level=200, requested_flight_level=200, initial_flight_level=200)
+    assert result == 0


### PR DESCRIPTION
It is reasonable to imagine an agent will ask for a fuel efficiency metric for an aircraft that does not have to climb or descend. This would raise a ZeroDivisionError.

Q: is there every a scenario where an aircraft does not have to climb/descend but an agent asks it to at some point as part of its manoeuvres? how is that currently handled?